### PR TITLE
relay: fix getSSRData function

### DIFF
--- a/packages/relay/src/QueryRenderer.js
+++ b/packages/relay/src/QueryRenderer.js
@@ -30,7 +30,8 @@ export default function QueryRenderer(props: Props) {
   const environment = Environment.getEnvironment(token, context);
 
   const getSSRData = () => {
-    if (typeof process !== 'undefined') {
+    if (typeof window === 'undefined') {
+      // What about react-native 🤔
       const store = environment.getStore();
       const { getRequest } = environment.unstable_internal;
       const operation = createOperationDescriptor(getRequest(props.query), props.variables);


### PR DESCRIPTION
It seems process gets injected into bundle. Checking if window
is defined instead. This will probably not work correctly in RN
environments. Improve later