### PR TITLE
withApp: use await fetchQuery only on server

### DIFF
--- a/packages/nextjs-utils/package.json
+++ b/packages/nextjs-utils/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "sideEffects": false,
   "dependencies": {
+    "@adeira/js": "^1.2.1",
     "@tbergq/components": "0.0.1",
-    "@tbergq/utils": "0.0.1",
     "@tbergq/relay": "0.0.1",
+    "@tbergq/utils": "0.0.1",
     "next": "^9.3.0",
     "next-cookies": "^2.0.3",
     "nprogress": "^0.2.0",

--- a/packages/nextjs-utils/src/withApp.js
+++ b/packages/nextjs-utils/src/withApp.js
@@ -10,6 +10,7 @@ import { TOKEN_KEY } from '@tbergq/utils';
 import { fetchQuery, Environment, RelayEnvironmentProvider } from '@tbergq/relay';
 import { createGlobalStyle } from 'styled-components';
 import { MediaContextProvider } from '@tbergq/components';
+import { isBrowser } from '@adeira/js';
 
 const GlobalStyle = createGlobalStyle({
   html: {
@@ -38,7 +39,7 @@ export default function withNProgress(Component: React.AbstractComponent<{ ... }
       const token = cookies[TOKEN_KEY];
       let ssrData;
 
-      if (props.pageProps.query != null) {
+      if (props.pageProps.query != null && !isBrowser()) {
         const environment = Environment.getEnvironment(token);
         await fetchQuery(environment, props.pageProps.query, props.pageProps.variables ?? {});
         ssrData = environment


### PR DESCRIPTION
this function is also being called on the client
and it prevents us from using cached data