### PR TITLE
tvh: deactivate eslint during builds

### DIFF
--- a/apps/tvhelper/next.config.js
+++ b/apps/tvhelper/next.config.js
@@ -81,5 +81,8 @@ module.exports = withVanillaExtract()(
     env: {
       GRAPHQL_URL,
     },
+    eslint: {
+      ignoreDuringBuilds: true,
+    },
   }),
 );


### PR DESCRIPTION
we already checked this, so no need to do it again